### PR TITLE
Optimasi, build, dan push ke master

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useState } from 'react'
+import Image from 'next/image'
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -23,10 +24,13 @@ export default function Header() {
           {/* Logo */}
           <div className="flex-shrink-0">
             <Link href="/" className="flex items-center">
-              <img 
+              <Image 
                 src="/timbangkan.jpg" 
                 alt="Melek Hukum ID" 
+                width={32}
+                height={32}
                 className="h-8 w-auto mr-2"
+                priority
               />
               <span className="text-xl font-bold text-gray-900">Melek Hukum ID</span>
             </Link>


### PR DESCRIPTION
Optimize logo image loading by replacing `<img>` with `next/image`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0217273f-4f8c-4c0d-b938-5ebaa1c8457a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0217273f-4f8c-4c0d-b938-5ebaa1c8457a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

